### PR TITLE
fix: SHA for post update

### DIFF
--- a/blog_dashboard.html
+++ b/blog_dashboard.html
@@ -270,10 +270,7 @@
         const homeView = document.getElementById('home-view');
         const detailView = document.getElementById('detail-view');
 
-        function openDetail(title, category) {
-            // Note: Content loading is handled by dashboard.js calling this
-            document.getElementById('detail-title').innerText = title || "New Post"; 
-            
+        function openDetail() {
             homeView.classList.add('hidden-view');
             detailView.classList.remove('hidden-view');
             
@@ -292,7 +289,10 @@
         }
 
         function createNewPost() {
-            // Reset Editor
+            // Reset Dashboard State
+            if(window.resetEditorState) window.resetEditorState();
+
+            // Reset Editor UI
             document.getElementById('editor-title').value = new Date().toISOString().split('T')[0] + '-new-post.md';
             document.getElementById('editor-content').value = "---\ntitle: New Post\ndate: " + new Date().toISOString().split('T')[0] + "\n---\n\n# New Post";
             
@@ -306,7 +306,7 @@
             // We should reload the window or handle this better. 
             
             // Hack for now: We just open the view. The save logic will see the filename doesn't match old path and treat as new.
-            openDetail('New Post', 'Draft');
+            openDetail();
             
             // Dispatch input event to trigger preview
             document.getElementById('editor-content').dispatchEvent(new Event('input'));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates editor state handling and SHA management to prevent save conflicts and streamline opening the editor.
> 
> - **Dashboard Logic (`dashboard.js`)**:
>   - Add `window.resetEditorState` to clear `currentFileSha`, `currentFilePath`, and `unsavedChanges` for new posts.
>   - After saving via `createOrUpdateFileContents`, update `currentFileSha` and `currentFilePath` from the response to prevent conflicts and handle renames.
>   - Change calls to `openDetail()` (no args).
> - **UI (`blog_dashboard.html`)**:
>   - Simplify `openDetail()` to take no arguments and update `createNewPost()` to call `resetEditorState` and then `openDetail()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 049e9d72da612ee448a13e56ec88ad267956ab28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->